### PR TITLE
Fix regexp in navbar-buffer-name for NTEmacs(compiled on mingw).

### DIFF
--- a/navbar.el
+++ b/navbar.el
@@ -406,7 +406,7 @@ Also, this runs :deinitialize functions without updating the navbar buffer."
 (defun navbar-buffer-name (&optional frame)
   (let ((string (prin1-to-string (or frame (selected-frame)))))
     ;; Match the frame address in core
-    (string-match " \\(0x[^ ]+\\)>\\'" string)
+    (string-match " \\([^ ]+\\)>\\'" string)
     (concat " *navbar " (match-string 1 string) "*")))
 
 (defun navbar-buffer (&optional frame)


### PR DESCRIPTION
NTEmacs 上で navbar-mode を実行した時に navbar-buffer-name で文字列マッチが失敗するためモードが有効にならない件を修正しました。

原因としては、NTEmacs の場合 mingw の printf("%p") の仕様のせいで
(print (selected-frame)) のアドレス部分の出力に "0x" のプリフィクスがついていないため、
" \(0x[^ ]+\)>\'" のパターンにひっかからず次の match-string でエラーになっていたためでした。
